### PR TITLE
Fix attribute errors and filing csvs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lm21_raw.csv lm21_raw.individual_disbursements.csv : lm21.json
 
 
 filing.json: filing.jl
-	cat $< |  jq -s '.[] | del(.detailed_form_data, .file_headers, .file_urls) | .files = .files[0]' | jq -s > $@
+	cat $< |  jq -s '.[] | del(.detailed_form_data, .file_headers, .file_urls) | .files = .files[0] | .file_path = .files.path | .file_checksum = .files.checksum | .file_status = .files.status | del(.files)' | jq -s > $@
 
 lm20.json : form.json
 	cat $< | jq 'with_entries( select(.value.formFiled == "LM-20")| del(.value.file_number, .value.person_filing, .value.signatures, .value.specific_activities, .value.formFiled))' > $@

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -168,10 +168,13 @@ class HeaderMimetypePipeline(FilesPipeline):
 
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
 
-        if type(headers.get("Content-Disposition")) is str:
-            content_disposition = headers.get("Content-Disposition")
-        else:
+        try:
             content_disposition = headers.get("Content-Disposition").decode()
+        except AttributeError as e:
+            if type(headers.get("Content-Disposition")) is str:
+                content_disposition = headers.get("Content-Disposition")
+            else:
+                raise e
 
         _, params = cgi.parse_header(content_disposition)
         filename = params["filename"]

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -168,7 +168,11 @@ class HeaderMimetypePipeline(FilesPipeline):
 
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
 
-        content_disposition = headers.get("Content-Disposition").decode()
+        if type(headers.get("Content-Disposition")) is str:
+            content_disposition = headers.get("Content-Disposition")
+        else:
+            content_disposition = headers.get("Content-Disposition").decode()
+
         _, params = cgi.parse_header(content_disposition)
         filename = params["filename"]
 

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -169,49 +169,47 @@ class HeaderMimetypePipeline(FilesPipeline):
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
 
         content_disposition = headers.get("Content-Disposition")
-        try:
-            # Occassionally comes in as a bytes object
-            content_disposition = content_disposition.decode()
-        except AttributeError:
-            pass
+        content_type = headers.get("Content-Type")
 
-        if content_disposition:
-            content_type = headers.get("Content-Type")
-            try:
-                # Occassionally comes in as a bytes object
-                content_type = content_type.decode()
-            except AttributeError:
-                pass
-
-            media_ext = self.get_media_ext(content_disposition, content_type)
-        else:
-            media_ext = ""
-
-        if media_ext is None:
-            media_ext = ""
-
-        if media_ext in {"", ".bin"}:
-            media_ext = ".pdf"
+        media_ext = self.get_media_ext(content_disposition, content_type)
 
         return f"full/{media_guid}{media_ext}"
     
-    def get_media_ext(self, content_disposition, content_type):
-        _, params = cgi.parse_header(content_disposition)
-        filename = params["filename"]
+    def get_media_ext(self, raw_content_disposition, raw_content_type):
+        if raw_content_disposition:
+            # Disposition and type occassionally come in as bytes objects
+            try:
+                content_disposition = raw_content_disposition.decode()
+            except AttributeError:
+                content_disposition = raw_content_disposition
 
-        media_ext = os.path.splitext(filename)[1]
+            try:
+                content_type = raw_content_type.decode()
+            except AttributeError:
+                content_type = raw_content_type
 
-        # Handles empty and wild extensions by trying to guess the
-        # mime type then extension or default to empty string otherwise
-        if media_ext not in mimetypes.types_map:
+            _, params = cgi.parse_header(content_disposition)
+            filename = params["filename"]
+
+            media_ext = os.path.splitext(filename)[1]
+
+            # Handles empty and wild extensions by trying to guess the
+            # mime type then extension or default to empty string otherwise
+            if media_ext not in mimetypes.types_map:
+                media_ext = ""
+                media_type = mimetypes.guess_type(filename)[0]
+
+                if media_type:
+                    media_ext = mimetypes.guess_extension(media_type)
+
+                elif content_type:
+                    media_ext = mimetypes.guess_extension(
+                        content_type.split(";")[0]
+                    )
+        else:
             media_ext = ""
-            media_type = mimetypes.guess_type(filename)[0]
 
-            if media_type:
-                media_ext = mimetypes.guess_extension(media_type)
+        if not media_ext or media_ext in {"", ".bin"}:
+            media_ext = ".pdf"
 
-            elif content_type:
-                media_ext = mimetypes.guess_extension(
-                    content_type.split(";")[0]
-                )
         return media_ext

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -168,18 +168,16 @@ class HeaderMimetypePipeline(FilesPipeline):
 
         media_guid = hashlib.sha1(to_bytes(request.url)).hexdigest()
 
-        try:
-            content_disposition = headers.get("Content-Disposition").decode()
-        except AttributeError as e:
-            if type(headers.get("Content-Disposition")) is str:
-                content_disposition = headers.get("Content-Disposition")
-            else:
-                raise e
+        content_disposition = headers.get("Content-Disposition")
 
-        _, params = cgi.parse_header(content_disposition)
-        filename = params["filename"]
+        if content_disposition:
+            _, params = cgi.parse_header(content_disposition)
+            filename = params["filename"]
 
-        media_ext = os.path.splitext(filename)[1]
+            media_ext = os.path.splitext(filename)[1]
+        else:
+            media_ext = ""
+
         # Handles empty and wild extensions by trying to guess the
         # mime type then extension or default to empty string otherwise
         if media_ext not in mimetypes.types_map:

--- a/reports/full/cb5efab9ea88d036a1f503f71f01485675846db1.html
+++ b/reports/full/cb5efab9ea88d036a1f503f71f01485675846db1.html
@@ -1,0 +1,1130 @@
+
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+
+
+
+
+	
+
+
+
+<html>
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=EDGE">
+<link rel="stylesheet" type="text/css" href="css/clickjack.css" />
+<script src="css/clickjack.js" type="text/javascript"></script>
+
+
+
+  
+    <title>LM20Form</title>
+  
+  
+
+
+<link rel="stylesheet" type="text/css" href="css/cssreset-min.css">
+<link rel="stylesheet" type="text/css" href="css/cssfonts-min.css">
+<link rel="stylesheet" type="text/css" href="css/cssgrids-min.css">
+<link rel="stylesheet" type="text/css" href="css/print.css">
+
+</head>
+
+
+<div id="custom-doc">
+
+	<div id="custom-printpage">
+		
+
+
+
+
+
+<script type="text/javascript" src="common/scripts.js">
+  Your browser does not support JavaScript.  This application will not function without JavaScript.  Use a browser that supports JavaScript.
+</script>
+
+<noscript class="ERDS-form-text-bold">
+  JavaScript has been disabled in your browser.  This application will not function without JavaScript.  Enable JavaScript in your browser.
+</noscript>
+
+
+
+
+<html xmlns:erds-extensions="xalan://gov.dol.olms.erds.query.ui.util.ERDSXSLExtensions" xmlns:xalan="http://xml.apache.org/xslt" ng-app="LM20App">
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link href="css/bootstrap.min.new.css" type="text/css" rel="stylesheet">
+<script type="text/javascript" src="/YUI/angular/scripts/jquery/jquery-1.11.1/jquery-1.11.1.js"></script><script type="text/javascript" src="/YUI/angular/scripts/angularjs_1_x/angular.min.js"></script><script>
+
+					angular.module('LM20App', [])
+					.controller('MainCtrl',
+					function($scope) {
+					$scope.greeting = "Hello World";
+					});  	
+						
+				</script>
+<style>
+
+
+					.verticalFont {
+					font-size: 1.5em;
+					font-weight: bold;
+					font-family:
+					sans-serif;
+
+					}
+
+					.verticalFORM {
+					Transform:
+					rotate(-90deg);
+					transform-origin: right,
+					top;
+					-ms-Transform:
+					rotate(-90deg);
+					-ms-transform-origin: right, top;
+					-webkit-transform:
+					rotate(-90deg);
+					-webkit-transform-origin: right,
+					top;
+					position:
+					absolute;
+					top: 20px;
+					left: -5px;
+					}
+
+
+					.verticalOLMS {
+					transform:
+					rotate(-270deg);
+					transform-origin: right,
+					top;
+					-ms-transform:
+					rotate(-270deg);
+					-ms-transform-origin: right, top;
+					-webkit-transform:
+					rotate(-270deg);
+					-webkit-transform-origin: right,
+					top;
+					position:
+					absolute;
+					top: 20px;
+					right: -5px ;
+					}
+
+					.verical_container {
+					position:
+					relative;
+					height: 90px;
+					}
+
+					.reportnameFont
+					{
+					font-size:
+					2em;
+					font-weight:
+					bold;
+					font-family:
+					sans-serif;
+					}
+					.olmsnameFont
+					{
+					font-size:
+					1.6em;
+					font-weight: bold;
+					font-family:
+					sans-serif;
+					text-align : right;
+					}
+
+
+					.rightBorder {
+					border-right: solid 2px ;
+					// margin-left : 7px;
+					}
+
+					.readCarfully {
+					padding-top :
+					5px;
+					font-style:
+					italic;
+					text-align :
+					center ;
+					font-size
+					: .9em ;
+
+
+					}
+
+					.tinyFont {
+					font-size
+					: .8em ;
+					}
+
+					.smallFont {
+					font-size : .8em
+					;
+					}
+
+					@page
+					{
+					size: auto;
+
+					margin-top
+					:
+					10mm;
+					margin-right :
+					5mm;
+					margin-bottom : 10mm;
+					margin-left : 6mm;
+
+					}
+
+					.notop {
+
+					border-top :
+					none ;
+					}
+
+
+
+					.cell-special {
+					height :
+					70px;
+
+					}
+					.cell-sm {
+					height : 40px;
+
+					}
+					.cell-md {
+					height : 190px;
+
+					}
+
+
+
+					.cell-lg {
+					height : 230px;
+
+					}
+
+					.cell-lg-210 {
+					height : 190px;
+
+					}
+
+					.cell-half {
+					height : 90px;
+
+					}
+
+					.myTable {
+					padding-top :
+					2px;
+					padding-right :
+					20px;
+					padding-bottom :
+					2px;
+					padding-left :
+					20px;
+					}
+					.myTable
+					[class*="col-"] hr
+					{
+					margin-top : 3px;
+					margin-bottom :
+					3px;
+					border: 0;
+					border-top : 1px
+					solid ;
+
+					}
+					.myTable
+					[class*="col-"] {
+					padding-top :0px;
+					padding-right :
+					0px;
+					padding-bottom : 0px;
+					padding-left : 0px;
+					border
+					:
+					1px solid ;
+					}
+
+					.myTable
+					[class*="col-"].notop {
+					border-top : none ;
+					}
+
+					.myTable
+					[class*="col-"].noleft {
+					border-left : none ;
+					}
+					
+					.myTable
+					[class*="col-"].noright {
+					border-right : none ;
+					}
+
+
+
+
+
+
+
+
+
+					.activityTable {
+					padding-top : 10px;
+					padding-right :
+					20px;
+					padding-bottom :
+					10px;
+					padding-left :
+					30px;
+					}
+
+					.activityTable
+					[class*="col-"] {
+					padding-top
+					:0px;
+					padding-right :
+					0px;
+					padding-bottom : 0px;
+					padding-left : 5px;
+					border
+					:
+					none ;
+					}
+
+
+
+					.activityTable .actvitiesInnerTable {
+					padding-left :
+					0px;
+					padding-right : 0px;}
+
+					.activityTable .actvitiesInnerTable
+					[class*="col-"] {
+					padding-top
+					:2px;
+					padding-right :
+					12px;
+					padding-left
+					:
+					0px;
+					padding-bottom : 0px;
+					border :
+					none ;
+
+					}
+
+
+					.rpt-pad-box {
+					margin-left
+					:
+					7px ;
+					}
+
+
+
+					.i-sectionNumberTable {
+					padding-top : 5px;
+					padding-right :
+					10px;
+					padding-bottom :
+					0px;
+					padding-left :
+					15px;
+					}
+
+					.i-sectionNumberTable
+					[class*="col-"] {
+					padding-top
+					:0px;
+					padding-right :
+					10px;
+					padding-bottom
+					: 0px;
+					padding-left : 5px;
+					border
+					:
+					none ;
+					}
+
+
+					.i-sectionbody {
+					padding-left :
+					10px;
+					padding-top
+					: 4px;
+					}
+
+					.i-sectionbody div{
+					padding-bottom :4px;
+					max-width:350px;
+					max-height:
+					20px;
+					overflow:
+					hidden;
+					white-space : nowrap ;
+
+					}
+
+					.i-terms {
+					max-width:550px;
+					overflow: hidden;
+
+					}
+
+					.i-label {
+					font-weight: bold ;
+					color : black;
+
+					padding-right : 5px;
+
+
+					}
+					.i-value{
+
+					padding-right : 5px;
+
+					}
+					.i-checkbox {
+					padding-left
+					:
+					5px;
+					padding-right :
+					5px;
+
+					}
+					
+					.i-xcheckbox{
+					  background-color: white;
+					  height:14px;
+					  width: 10px;
+					  border: 1px solid black;
+					  padding: 2px;
+					  margin:4px;
+					}
+					
+					.i-nocheckbox{
+					  background-color: white;
+					  width: 2px;
+					  border: 1px solid black;
+					  padding-left:2px;
+					  padding-right:9px;
+					  padding-bottom:0px;
+					  padding-bottom:0px;
+					  margin:4px;
+					}
+
+					.fontbold {
+					font-weight : bold
+					;
+					}
+
+
+					body {
+					font-size
+					: 1.2em;
+					}
+
+
+
+					@media
+					screen {
+					#custom-doc {
+					background-color:
+					gray;
+					padding-top: 15px;
+					margin: auto;
+					padding-bottom: 50px;
+					}
+					#custom-printpage {
+					border-width: 10px;
+					border-style: solid;
+					border-color: white;
+					margin:
+					auto;
+					width: 800px;
+					background-color:
+					white;
+					min-width : 800px;
+
+
+					}
+					}
+					.report-container {
+
+					}
+
+					table.addTable {
+					border-collapse: collapse;
+					width: 98.6%;
+					border: 1px
+					solid black;
+					margin-left : 5px ;
+
+					padding-bottom :5px ;
+					}
+
+					table.addTable thead th{
+					text-align
+					: left;
+					padding: 1px;
+					}
+
+					table.addTable th ,table.addTable td
+					{
+					text-align:
+					left;
+					padding:
+					4px;
+					border: 1px solid black;
+					}
+
+					table.addTable
+					tr:nth-child(even){background-color: #f2f2f2;
+					}
+
+					.seeAttached {
+					font-style : italic ;
+					padding : 15px;
+
+					}
+					@media print {
+					.hideIfPrint {
+					display : none
+					}
+					}
+
+					@media screen {
+					.hideIfScreen {
+					display : none
+					}
+					}
+					
+								
+					
+				</style>
+</head>
+<body ng-controller="MainCtrl">
+<div class="report-container">
+<div class="row">
+<div class="col-xs-12 rightBorder">
+<div class="row">
+<div class="col-xs-2">
+<div class="verical_container">
+<div class="verticalFORM verticalFont">FORM</div>
+</div>
+</div>
+<div class="col-xs-22 reportnameFont">
+<div>LM-20 - AGREEMENT</div>
+<div>&amp; ACTIVITIES REPORT</div>
+</div>
+</div>
+<div class="tinyFont">
+<div>
+										OMB No.
+										1245-0003
+										.
+
+										Expires
+										09-30-2021
+										.
+									</div>
+<div>IMPORTANT: This report is mandatory under P.L. 86-257, as
+										amended. Failure to comply may result in criminal prosecution,
+										fines, or civil penalties as provided by 29 U.S.C. 439 or 440.
+										Required of persons, including Labor Relations Consultants and
+										Other Individuals and Organizations, under Section 203(b) of
+										the
+										Labor-Management Reporting and Disclosure Act of 1959, as
+										amended (LMRDA).</div>
+</div>
+</div>
+<div class="col-xs-12">
+<div class="row">
+<div class="col-xs-22">
+<div class="olmsnameFont">Office of Labor-Management Standards</div>
+<div class="olmsnameFont">U.S. Department of Labor</div>
+<div style="height:80px;" class="rpt-pad-box">
+<div>For Official Use Only</div>
+<div style="font-weight:bold;">E</div>
+</div>
+</div>
+<div class="col-xs-2">
+<div class="verical_container">
+<div class="verticalOLMS verticalFont">OLMS</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-17 col-xs-offset-4"></div>
+</div>
+</div>
+</div>
+<div class="readCarfully">
+<span aria-hidden="true" class="glyphicon glyphicon-triangle-right"></span>
+							Read the instructions carefully before completing this report.
+							<span aria-hidden="true" class="glyphicon glyphicon-triangle-left"></span>
+</div>
+<div class="myTable">
+<div class="row">
+<div class="col-xs-8">
+<span class="i-label">1.a. File Number: C-</span><span class="i-value">68722</span>
+</div>
+<div class="col-xs-8 noleft noright">
+<span class="i-label"></span>
+</div>
+<div class="col-xs-8 noleft">
+<span class="i-label">
+									Amended:
+													<span class="i-nocheckbox"></span></span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-12 cell-lg-210 notop">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">2.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Name and mailing address (including Zip Code):</span>
+</div>
+</div>
+</div>
+<div class="i-sectionbody">
+<div>
+<span class="i-label">Name:</span><span class="i-value">Deborah Long</span>
+</div>
+<div>
+<span class="i-label">Title:</span><span class="i-value">President</span>
+</div>
+<div>
+<span class="i-label">Organization:</span><span class="i-value">Employer Labor Solutions</span>
+</div>
+<div>
+<span class="i-label">P.O. Box., Bldg., Room No., if any:</span><span class="i-value">Suite 251-151</span>
+</div>
+<div>
+<span class="i-label">Street:</span><span class="i-value">4843 Colleyville Blvd.</span>
+</div>
+<div>
+<span class="i-label">City:</span><span class="i-value">Colleyville</span><span class="i-label">State:</span><span class="i-value">TX</span>
+</div>
+<div>
+<span class="i-label">ZIP code:</span>76034</div>
+</div>
+</div>
+<div class="col-xs-12 cell-lg-210 notop noleft">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">3.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Other address where records necessary to
+													verify this report are kept:</span>
+</div>
+</div>
+</div>
+<div class="i-sectionbody">
+<div>
+<span class="i-label">Name:</span><span class="i-value"> </span>
+</div>
+<div>
+<span class="i-label">Title:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">Organization:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">P.O. Box., Bldg., Room No., if any:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">Street:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">City:</span><span class="i-value"></span><span class="i-label">State:</span>
+</div>
+<div>
+<span class="i-label">ZIP code:</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-12 notop cell-half">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">4.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Date fiscal year ends:</span><span class="i-value"><span class="i-value">Dec /</span>31</span>
+</div>
+</div>
+</div>
+</div>
+<div class="col-xs-12 notop noleft cell-half">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">5.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Type of person</span>
+</div>
+</div>
+</div>
+<div class="i-sectionbody">
+
+										a.
+										<span class="i-nocheckbox"></span>
+										Individual &nbsp; &nbsp; &nbsp; b.
+										<span class="i-nocheckbox"></span>
+										Partnership
+
+									</div>
+<div class="i-sectionbody">
+
+										c.
+										<span class="i-xcheckbox">X</span>
+										Corporation C d.
+										<span class="i-nocheckbox"></span>
+										Other
+
+
+									</div>
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label"></span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Specify:</span><span class="i-value"></span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<br>
+<div class="row">
+<div class="col-xs-24">
+<span class="i-label"> &nbsp; Nature of Agreement or Arrangement</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-12 notop cell-lg-210">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">6.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Full name and address of employer  with whom made (include ZIP Code):</span>
+</div>
+</div>
+</div>
+<div class="i-sectionbody">
+<div>
+<span class="i-label">Name:</span><span class="i-value">Darryl Franklin</span>
+</div>
+<div>
+<span class="i-label">Organization:</span><span class="i-value">HMSHOST CORPORATION</span>
+</div>
+<div>
+<span class="i-label">Trade Name, if any:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">P.O. Box., Bldg., Room No., if any:</span><span class="i-value"></span>
+</div>
+<div>
+<span class="i-label">Street:</span><span class="i-value">6905 ROCKLEDGE DR</span>
+</div>
+<div>
+<span class="i-label">City:</span><span class="i-value">BETHESDA</span><span class="i-label">State:</span><span class="i-value">MD</span>
+</div>
+<div>
+<span class="i-label">ZIP code:</span>20817</div>
+</div>
+</div>
+<div class="col-xs-12 notop noleft cell-lg-210">
+<div class="cell-sm">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">7.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">
+														Date entered into</span><span class="i-value">03/04/2020</span>
+</div>
+</div>
+</div>
+</div>
+<hr>
+<div class="cell-md">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">8.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Name of person(s) through whom made:</span>
+</div>
+</div>
+</div>
+<div class="i-sectionbody">
+<div>
+<span class="i-label">Name:</span><span class="i-value">Deborah Long</span>
+</div>
+<div>
+<span class="i-label">Name:</span><span class="i-value">Darryl Franklin</span>
+</div>
+<div></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h5 class="rpt-instruction-centered">Signature and Verification</h5>
+<div class="myTable">
+<div class="row">
+<div style="padding : 5px;" class="col-xs-24">
+<span class="tinyFont">Each
+										of the undersigned declares, under penalty
+										of
+										perjury
+										and
+										other
+										applicable penalties of law, that all of the
+										information
+										submitted in this report (including the information
+										contained in
+										any accompanying documents) has been examined by
+										the
+										signatory
+										and
+										is, to the best of the undersigned's
+										knowledge
+										and
+										belief,
+										true, correct, and complete. (See Section
+										VII on
+										penalties in the
+										instructions.)</span>
+<div class="activityTable">
+<div class="row">
+<div class="col-xs-12">
+<div class="myTable">
+<div class="row">
+<div class="col-xs-2">
+<span class="i-label">13.</span>
+</div>
+<div class="col-xs-22">
+<span class="i-label">
+						SIGNED:
+					</span><span class="i-value">Deborah   Long</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-22">
+<span class="i-label">
+						Title:
+					</span><span class="i-value">PRESIDENT</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-22">
+<span class="i-label">
+						Date:
+					</span><span class="i-value">Apr 08, 2020</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-15">
+<span class="i-label">
+						Telephone Number:
+					</span><span class="i-value">877-424-9799</span>
+</div>
+</div>
+</div>
+</div>
+<div class="col-xs-12">
+<div class="myTable">
+<div class="row">
+<div class="col-xs-2">
+<span class="i-label">14.</span>
+</div>
+<div class="col-xs-22">
+<span class="i-label">
+						SIGNED:
+					</span><span class="i-value">Deborah   Long</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-22">
+<span class="i-label">
+						Title:
+					</span><span class="i-value">TREASURER</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-22">
+<span class="i-label">
+						Date:
+					</span><span class="i-value">Apr 08, 2020</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-2"></div>
+<div class="col-xs-15">
+<span class="i-label">
+						Telephone Number:
+					</span><span class="i-value">877-424-9799</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="versionFooter">Form LM-20 (2003)</div>
+<div class="myTable">
+<div class="row">
+<div class="col-xs-24">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">9.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Check the appropriate box(es) to indicate
+														whether an object
+														of the activities undertaken is directly
+														or
+														indirectly:</span>
+</div>
+</div>
+</div>
+<div class="activityTable">
+<div class="row">
+<div class="col-xs-1">a.</div>
+<div class="col-xs-1">
+<span class="i-xcheckbox">X</span>
+</div>
+<div class="col-xs-22">To persuade employees to exercise or not to
+													exercise, or persuade employees as to the manner of
+													exercising, the right to organize and bargain collectively
+													through representatives of their own choosing.</div>
+</div>
+<div class="row">
+<div class="col-xs-1">b.</div>
+<div class="col-xs-1">
+<span class="i-nocheckbox"></span>
+</div>
+<div class="col-xs-22">To supply an employer with information
+													concerning the activities of employees or a labor
+													organization in connection with a labor dispute involving
+													such employer, except information for use solely in
+													conjunction with an administrative or arbitral proceeding
+													or
+													a criminal or civil judicial proceeding.</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="myTable">
+<div class="row">
+<div class="col-xs-24">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">10.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Terms and conditions.</span>
+													(Explain in detail;
+													see
+													instructions.
+													Written agreements must
+													be attached.):
+												</div>
+</div>
+</div>
+<div class="activityTable">
+<div class="row">
+<span><span class="i-nocheckbox"></span></span><span class="i-value">Written Agreement/Arrangement</span>
+</div>
+<div class="row">
+<div class="col-xs-22">All services described in Section 11a below shall be performed on an hourly fee basis. Expenses in connection with the performance of such services as accommodations, meals, travel, etc. will be billed at cost and reimbursed to Employer Labor Solutions.</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="myTable">
+<div class="row">
+<div class="col-xs-24">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-23">
+<span class="i-label">Specific Activities to be performed</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div>
+<div>
+<span class="i-label">Activity</span><span class="i-label">1</span>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-24">
+<span class="i-label">11. For each activity, separately list in detail the information required.</span>
+													(See instructions.)
+												</div>
+</div>
+<div class="row">
+<div class="col-xs-24 notop">
+<span class="i-label">a. Nature of activity:</span><span class="i-value">Employer Labor Solutions has been retained to assist the employer in communicating with its employees, when management is unable to do so, with regard to the manner in which they exercise their rights to organize and bargain collectively under the National Labor Relations Act.</span>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-12 notop cell-special">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-22 cell-xs">
+<span class="i-label">11.b.Period during which activities
+														performed:</span>
+</div>
+</div>
+</div>
+<div style="padding-left :10px;">
+<span class="i-value">03/04/2020</span>
+</div>
+</div>
+<div class="col-xs-12 noleft notop cell-special">
+<div style="overflow:hidden">
+<span class="i-label">11.c. Extent of performance:</span>
+<div class="i-sectionbody">
+<div class="i-value">03/17/2020</div>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-24 notop">
+<div>
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">11.d.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Name and address of person(s) through
+															whom
+															activities were performed or will be performed:</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="i-sectionNumberTable">
+<span><span class="i-label">&nbsp; Name:</span><span class="i-value">Veronica Bodart</span></span><span><span class="i-label">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Organization:</span><span class="i-value">Employer Labor Solutions</span></span>
+</div>
+<div class="i-sectionNumberTable">
+<span><span class="i-label"> &nbsp; P.O. Box, Bldg., Room No., If any:</span><span class="i-value">Suite 251-151</span></span><span><span class="i-label">Street:</span><span class="i-value">4843 Colleyville Blvd.</span></span><span><span class="i-label">City:</span><span class="i-value">Colleyville</span></span><span><span class="i-label">State:</span><span class="i-value">TX</span></span><span><span class="i-label">Zip:</span>76034</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-24 notop">
+<div>
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-1">
+<span class="i-label">11.d.</span>
+</div>
+<div class="col-xs-23">
+<span class="i-label">Name and address of person(s) through
+															whom
+															activities were performed or will be performed:</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="i-sectionNumberTable">
+<span><span class="i-label">&nbsp; Name:</span><span class="i-value">Juan Cruz</span></span><span><span class="i-label">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Organization:</span><span class="i-value">Employer Labor Solutions</span></span>
+</div>
+<div class="i-sectionNumberTable">
+<span><span class="i-label"> &nbsp; P.O. Box, Bldg., Room No., If any:</span><span class="i-value">Suite 251-151</span></span><span><span class="i-label">Street:</span><span class="i-value">4843 Colleyville Blvd.</span></span><span><span class="i-label">City:</span><span class="i-value">Colleyville</span></span><span><span class="i-label">State:</span><span class="i-value">TX</span></span><span><span class="i-label">Zip:</span>76034</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-24 notop">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-23">
+<span class="i-label"> 12.a. Identify subject groups of employees:</span>
+</div>
+</div>
+<div class="i-sectionbody">
+<span class="i-value">Full-Time and Part-Time Employees</span>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-xs-24 notop">
+<div class="i-sectionNumberTable">
+<div class="row">
+<div class="col-xs-23">
+<span class="i-label"> 12.b. Identify subject labor organizations:</span>
+</div>
+</div>
+<div>
+<div class="i-sectionbody">
+<span class="i-value">UNITE HERE( LOCAL UNION  23  AIRPORT CONCESSIONS &amp; INFLIGHT) - 544240</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="versionFooter">Form LM-20 (2003)</div>
+</div>
+</div>
+</body>
+</html>
+
+ 
+
+
+	</div>
+
+</div>
+
+</html>
+
+


### PR DESCRIPTION
## Overview

All of the `content-dispositions` when looking for filenames as of late have been either of type `str` or `None`. So the `decode()` method that has been in use has been raising `AttributeErrors`. This branch accounts for the `content-disposition` being a string, and passes the filename found within.

After resolving that error, `jq` had issues parsing out the `files` attributes of objects in `filing.json` to a csv since they were nested objects. This branch also flattens out that object with a make command to get the csv working.

- Closes #12 

## Testing Instructions

 * Run `make lm20.db` or look at the checks performed on this PR
 * Confirm that everything in the "build database" portion runs without the str attribute error
 * Confirm that the data in the db is what we expect