### PR TITLE
Factor out cgi (deprecated in Python 3.13)

### DIFF
--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -1,9 +1,9 @@
 import datetime
+from email.message import Message
 import hashlib
 import mimetypes
 import os
 import re
-import requests
 
 import dateutil.parser
 
@@ -188,8 +188,11 @@ class HeaderMimetypePipeline(FilesPipeline):
             except AttributeError:
                 content_type = raw_content_type
 
-            _, params = requests.utils._parse_content_type_header(content_disposition)
-            filename = params["filename"]
+            m = Message()
+            m["content-type"] = content_disposition
+            (filename,) = [
+                value for param, value in m.get_params() if param == "filename"
+            ]
 
             media_ext = os.path.splitext(filename)[1]
 

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -2,8 +2,8 @@ import datetime
 import hashlib
 import mimetypes
 import os
-import cgi
 import re
+import requests
 
 import dateutil.parser
 
@@ -174,7 +174,7 @@ class HeaderMimetypePipeline(FilesPipeline):
         media_ext = self.get_media_ext(content_disposition, content_type)
 
         return f"full/{media_guid}{media_ext}"
-    
+
     def get_media_ext(self, raw_content_disposition, raw_content_type):
         if raw_content_disposition:
             # Disposition and type occassionally come in as bytes objects
@@ -188,7 +188,7 @@ class HeaderMimetypePipeline(FilesPipeline):
             except AttributeError:
                 content_type = raw_content_type
 
-            _, params = cgi.parse_header(content_disposition)
+            _, params = requests.utils._parse_content_type_header(content_disposition)
             filename = params["filename"]
 
             media_ext = os.path.splitext(filename)[1]

--- a/lm20/pipelines.py
+++ b/lm20/pipelines.py
@@ -189,10 +189,8 @@ class HeaderMimetypePipeline(FilesPipeline):
                 content_type = raw_content_type
 
             m = Message()
-            m["content-type"] = content_disposition
-            (filename,) = [
-                value for param, value in m.get_params() if param == "filename"
-            ]
+            m["content-disposition"] = content_disposition
+            filename = m.get_filename()
 
             media_ext = os.path.splitext(filename)[1]
 

--- a/lm20/spiders/filings.py
+++ b/lm20/spiders/filings.py
@@ -1,4 +1,4 @@
-import requests
+from email.message import Message
 
 from scrapy import Spider
 from scrapy.http import FormRequest, Request
@@ -116,9 +116,9 @@ class LM20(Spider):
 
         # baffling, sometimes when you request some resources
         # it returns html and sometime it returns a pdf
-        content_type, _ = requests.utils._parse_content_type_header(
-            response.headers.get("Content-Type").decode()
-        )
+        m = Message()
+        m["content-type"] = response.headers.get("Content-Type").decode()
+        content_type, _ = m.get_params()[0]
 
         keep_trying = True
 

--- a/lm20/spiders/filings.py
+++ b/lm20/spiders/filings.py
@@ -118,7 +118,7 @@ class LM20(Spider):
         # it returns html and sometime it returns a pdf
         m = Message()
         m["content-type"] = response.headers.get("Content-Type").decode()
-        content_type, _ = m.get_params()[0]
+        content_type = m.get_content_type()
 
         keep_trying = True
 

--- a/lm20/spiders/filings.py
+++ b/lm20/spiders/filings.py
@@ -1,4 +1,4 @@
-import cgi
+import requests
 
 from scrapy import Spider
 from scrapy.http import FormRequest, Request
@@ -116,7 +116,7 @@ class LM20(Spider):
 
         # baffling, sometimes when you request some resources
         # it returns html and sometime it returns a pdf
-        content_type, _ = cgi.parse_header(
+        content_type, _ = requests.utils._parse_content_type_header(
             response.headers.get("Content-Type").decode()
         )
 


### PR DESCRIPTION
## Description

Nightly builds of this data have been failing due to use of the `cgi` module, which was deprecated in Python 3.13. I replaced `cgi.parse_header` calls with equivalent code from the `email` module. See: https://peps.python.org/pep-0594/#cgi

I could have also pinned CI to a compatible version of Python, e.g., <= 2.12, but this doesn't seem like a compelling reason to be constrained.

Connects https://github.com/datamade/devops/issues/140

## Testing instructions

I triggered a build of the `filing.jl` file locally and confirmed records began to come in as expected. Let me know if there are other testing steps we should take for this/future PRs.