### PR TITLE
Add keepalive job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,11 @@ jobs:
           asset_content_type: application/ld+json # required by GitHub API
           max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
           ignore_hash: true
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
This PR adds a keepalive job to scheduled actions using [
https://github.com/marketplace/actions/workflow-keepalive](
https://github.com/marketplace/actions/workflow-keepalive).

The keepalive workflow used by other repositories in this repo has been [removed for violating GitHub's terms of service](
https://github.com/gautamkrishnar/keepalive-workflow). See the note [in the maintainer's GitHub profile](
https://github.com/gautamkrishnar).

The workflow I use here uses the GitHub API to enable the job, instead of creating dummy commits.

If this is ok with you, @fgregg, I'll add it to the LM-10 repo, too.