### PR TITLE
Pin scrapy to <2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scrapy
+scrapy<2.13
 csvs-to-sqlite
 sqlite-utils
 https://github.com/LuighiV/csvs-to-sqlite/archive/refs/heads/main.zip


### PR DESCRIPTION
[The latest scrapy release](https://github.com/scrapy/scrapy/releases/tag/2.13.0) coincides with scrape failures. It may be desirable to use async scraping, now the default, but in the meantime, this PR pins to the last working release to keep data moving.